### PR TITLE
Fix crop ui

### DIFF
--- a/webserver/static/css/feverscreen.css
+++ b/webserver/static/css/feverscreen.css
@@ -220,8 +220,11 @@ body {
 #status-text > span {
     display: block;
 }
-#app.scan #fov-box, #app.ffc #fov-box, #app.init #fov-box {
+#fov-box {
     display: none;
+}
+#app.calibrate #fov-box {
+    display: block;
 }
 #fov-box {
     position: absolute;

--- a/webserver/static/css/feverscreen.css
+++ b/webserver/static/css/feverscreen.css
@@ -220,7 +220,7 @@ body {
 #status-text > span {
     display: block;
 }
-#fov-box {
+#fov-box, #app.calibrate.ffc #fov-box {
     display: none;
 }
 #app.calibrate #fov-box {


### PR DESCRIPTION
Change sense of when crop-ui is shown, so that it is hidden on app startup, and shown when in calibrate mode.