### PR TITLE
Reuse existing calibration settings if they are less than an

### DIFF
--- a/webserver/static/css/feverscreen.css
+++ b/webserver/static/css/feverscreen.css
@@ -57,6 +57,27 @@ body {
     text-align: left;
     margin: 20px 0 5px 0;
 }
+#recalibrate-prompt {
+    display: flex;
+    align-items: center;
+}
+#recalibrate-prompt .overlay-content {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
+    position: relative;
+}
+#recalibrate-prompt button:first-child {
+    left: 4vw;
+}
+#recalibrate-prompt button:last-child {
+    right: 4vw;
+}
+#recalibrate-prompt button {
+    position: absolute;
+    min-width: 33%;
+    font-size: 4vmin;
+}
 
 @media screen and (max-height: 450px) {
     .overlay a {

--- a/webserver/static/html/fever.html
+++ b/webserver/static/html/fever.html
@@ -15,7 +15,15 @@
 	<link rel="stylesheet" href="/static/css/feverscreen.css"/>
 </head>
 <body>
-
+<div class="overlay" id="recalibrate-prompt">
+	<div class="overlay-content">
+		<h2></h2>
+		<div>
+			<button class="confirm-yes">Yes</button>
+			<button class="confirm-no">No</button>
+		</div>
+	</div>
+</div>
 <div id="myNav" class="overlay">
 	<div class="overlay-content">
 		<h2 id="overlay-message">Settings</h2>


### PR DESCRIPTION
hour old.
Every time the page is loaded, prompt the user to reuse existing
settings, because we still need to capture user input for browser
permissions reasons.