### PR TITLE
Request ffc

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,6 +53,7 @@ nfpms:
     "_release/feverscreen.service": "/etc/systemd/system/feverscreen.service"
     "_release/leptond.service": "/etc/systemd/system/leptond.service"
     "webserver/_release/managementd-avahi.service": "/etc/avahi/services/managementd.service"
+    "_release/org.cacophony.leptond.conf": "/etc/dbus-1/system.d/org.cacophony.leptond.conf"
   scripts:
     postinstall: "_release/postinstall.sh"
 

--- a/_release/leptond.service
+++ b/_release/leptond.service
@@ -7,7 +7,7 @@ Type=simple
 ExecStart=/usr/bin/leptond
 Restart=on-failure
 RestartSec=5s
-WatchdogSec=1m
+WatchdogSec=2m
 
 # Give real-time priority
 CPUSchedulingPolicy=fifo

--- a/_release/org.cacophony.leptond.conf
+++ b/_release/org.cacophony.leptond.conf
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?> <!-- -*- XML -*- -->
+
+<!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <policy user="root">
+    <allow own="org.cacophony.leptond"/>
+  </policy>
+
+  <policy context="default">
+    <allow send_destination="org.cacophony.leptond"/>
+  </policy>
+</busconfig>

--- a/cmd/leptond/main.go
+++ b/cmd/leptond/main.go
@@ -91,6 +91,11 @@ func runMain() error {
 	}
 	logConfig(conf)
 
+	service, err := startService()
+	if err != nil {
+		return err
+	}
+
 	log.Print("host initialisation")
 	if _, err := host.Init(); err != nil {
 		return err
@@ -111,6 +116,7 @@ func runMain() error {
 
 	for {
 		camera, err = initialiseLepton(conf)
+		service.addCamera(camera)
 		if err != nil {
 			return err
 		}
@@ -131,6 +137,7 @@ func runMain() error {
 		}
 
 		log.Print("closing camera")
+		service.removeCamera()
 		camera.Close()
 
 		err = cycleCameraPower(conf.PowerPin)

--- a/cmd/leptond/service.go
+++ b/cmd/leptond/service.go
@@ -1,0 +1,97 @@
+// feverscreen
+//  Copyright (C) 2020, The Cacophony Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/TheCacophonyProject/lepton3"
+	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/introspect"
+)
+
+const (
+	dbusName = "org.cacophony.leptond"
+	dbusPath = "/org/cacophony/leptond"
+)
+
+var mu sync.Mutex
+
+type leptondService struct {
+	camera *lepton3.Lepton3
+}
+
+func startService() (*leptondService, error) {
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		return nil, err
+	}
+	reply, err := conn.RequestName(dbusName, dbus.NameFlagDoNotQueue)
+	if err != nil {
+		return nil, err
+	}
+	if reply != dbus.RequestNameReplyPrimaryOwner {
+		return nil, errors.New("name already taken")
+	}
+	s := &leptondService{}
+	conn.Export(s, dbusPath, dbusName)
+	conn.Export(genIntrospectable(s), dbusPath, "org.freedesktop.DBus.Introspectable")
+	return s, nil
+}
+
+func genIntrospectable(v interface{}) introspect.Introspectable {
+	node := &introspect.Node{
+		Interfaces: []introspect.Interface{{
+			Name:    dbusName,
+			Methods: introspect.Methods(v),
+		}},
+	}
+	return introspect.NewIntrospectable(node)
+}
+
+func (s *leptondService) addCamera(camera *lepton3.Lepton3) {
+	mu.Lock()
+	defer mu.Unlock()
+	s.camera = camera
+}
+
+func (s *leptondService) removeCamera() {
+	mu.Lock()
+	defer mu.Unlock()
+	s.camera = nil
+}
+
+func (s leptondService) RunFFC() *dbus.Error {
+	mu.Lock()
+	defer mu.Unlock()
+	if s.camera == nil {
+		return makeDbusError(".RunFFC", fmt.Errorf("no camera available"))
+	}
+	if err := s.camera.RunFFC(); err != nil {
+		return makeDbusError(".RunFFC", err)
+	}
+	return nil
+}
+
+func makeDbusError(name string, err error) *dbus.Error {
+	return &dbus.Error{
+		Name: dbusName + name,
+		Body: []interface{}{err.Error()},
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/TheCacophonyProject/go-api v0.0.0-20200210030345-722430c24511
 	github.com/TheCacophonyProject/go-config v1.4.0
 	github.com/TheCacophonyProject/go-cptv v0.0.0-20200225002107-8095b1b6b929
-	github.com/TheCacophonyProject/lepton3 v0.0.0-20200331221130-742935ad7314
+	github.com/TheCacophonyProject/lepton3 v0.0.0-20200430221413-9df342ce97f9
 	github.com/TheCacophonyProject/management-interface v1.6.0
 	github.com/TheCacophonyProject/rtc-utils v1.3.0
 	github.com/TheCacophonyProject/window v0.0.0-20200312071457-7fc8799fdce7

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,6 @@ github.com/TheCacophonyProject/go-cptv v0.0.0-20200116020937-858bd8b71512/go.mod
 github.com/TheCacophonyProject/go-cptv v0.0.0-20200225002107-8095b1b6b929 h1:Ew+XHCyNuokz/1mmsyMBvpdDfYgwGd1Wc9V+RfWvTWM=
 github.com/TheCacophonyProject/go-cptv v0.0.0-20200225002107-8095b1b6b929/go.mod h1:Vg73Ezn4kr8qDNP9LNgjki9qgi+5T/0Uc9oDyflaYUY=
 github.com/TheCacophonyProject/lepton3 v0.0.0-20200121020734-2ae28662e1bc/go.mod h1:xzPAWtvVCbJdJC2Gn1cG0Ovs/VP7XGGiQpUU8wU4HME=
-github.com/TheCacophonyProject/lepton3 v0.0.0-20200331221130-742935ad7314 h1:JkYZgzcILiO2j9CxWHprUBH6PzjpbVtds+zUMPfqU0o=
-github.com/TheCacophonyProject/lepton3 v0.0.0-20200331221130-742935ad7314/go.mod h1:W+t2+4QW22Tv/Vc6m0jwtm1S115o2kJKPdd28wV5LeA=
 github.com/TheCacophonyProject/lepton3 v0.0.0-20200430221413-9df342ce97f9 h1:WuMZ1bqqxS5YgzduhQp0MEuA/YEOo3irfHN/DTlwBvA=
 github.com/TheCacophonyProject/lepton3 v0.0.0-20200430221413-9df342ce97f9/go.mod h1:W+t2+4QW22Tv/Vc6m0jwtm1S115o2kJKPdd28wV5LeA=
 github.com/TheCacophonyProject/management-interface v1.6.0 h1:LOb8AoDLZp03ev83JiIZ0Sk7QZKEGvhcHMrcc2qJUFA=

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/TheCacophonyProject/go-cptv v0.0.0-20200225002107-8095b1b6b929/go.mod
 github.com/TheCacophonyProject/lepton3 v0.0.0-20200121020734-2ae28662e1bc/go.mod h1:xzPAWtvVCbJdJC2Gn1cG0Ovs/VP7XGGiQpUU8wU4HME=
 github.com/TheCacophonyProject/lepton3 v0.0.0-20200331221130-742935ad7314 h1:JkYZgzcILiO2j9CxWHprUBH6PzjpbVtds+zUMPfqU0o=
 github.com/TheCacophonyProject/lepton3 v0.0.0-20200331221130-742935ad7314/go.mod h1:W+t2+4QW22Tv/Vc6m0jwtm1S115o2kJKPdd28wV5LeA=
+github.com/TheCacophonyProject/lepton3 v0.0.0-20200430221413-9df342ce97f9 h1:WuMZ1bqqxS5YgzduhQp0MEuA/YEOo3irfHN/DTlwBvA=
+github.com/TheCacophonyProject/lepton3 v0.0.0-20200430221413-9df342ce97f9/go.mod h1:W+t2+4QW22Tv/Vc6m0jwtm1S115o2kJKPdd28wV5LeA=
 github.com/TheCacophonyProject/management-interface v1.6.0 h1:LOb8AoDLZp03ev83JiIZ0Sk7QZKEGvhcHMrcc2qJUFA=
 github.com/TheCacophonyProject/management-interface v1.6.0/go.mod h1:56VgQqLkRW7Kyxel9kOcpKPsrlhFv2CdG8dv6WkO+jY=
 github.com/TheCacophonyProject/modemd v0.0.0-20190605010435-ae5b0f2eb760/go.mod h1:bfwJ/WcvDY9XtHKC5tcRfVrU8RWaW8DLYAAUfsrJr/4=

--- a/motion/motionprocessor.go
+++ b/motion/motionprocessor.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	maxFFCWarmupDuration = 5 * time.Minute
+	maxFFCWarmupDuration = 10 * time.Minute
 	ffcTriggerPeriod     = 5 * time.Second
 	targetTempFile       = "/etc/cacophony/camera-target-temp"
 

--- a/motion/motionprocessor.go
+++ b/motion/motionprocessor.go
@@ -18,6 +18,7 @@ package motion
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"math"
@@ -29,15 +30,21 @@ import (
 	"sync"
 	"time"
 
+	config "github.com/TheCacophonyProject/go-config"
 	"github.com/TheCacophonyProject/go-cptv/cptvframe"
 	"github.com/TheCacophonyProject/window"
-
-	config "github.com/TheCacophonyProject/go-config"
 	"github.com/feverscreen/feverscreen/loglimiter"
 	"github.com/feverscreen/feverscreen/recorder"
+	"github.com/godbus/dbus"
 )
 
-const minLogInterval = time.Minute
+const (
+	maxFFCWarmupDuration = 5 * time.Minute
+	ffcTriggerPeriod     = 5 * time.Second
+	targetTempFile       = "/etc/cacophony/camera-target-temp"
+
+	minLogInterval = time.Minute
+)
 
 type FrameParser func([]byte, *cptvframe.Frame) error
 
@@ -50,6 +57,8 @@ func NewMotionProcessor(
 	recorder recorder.Recorder, c cptvframe.CameraSpec,
 ) *MotionProcessor {
 	go readTemps()
+	readCameraTargetTemp()
+	log.Printf("camera target temp is %v", targetCameraTemp)
 	return &MotionProcessor{
 		parseFrame:     parseFrame,
 		minFrames:      recorderConf.MinSecs * c.FPS(),
@@ -68,9 +77,24 @@ func NewMotionProcessor(
 }
 
 var (
-	temps = []int{}
-	mu    sync.Mutex
+	temps            = []int{}
+	mu               sync.Mutex
+	targetCameraTemp = 28.0
 )
+
+func readCameraTargetTemp() {
+	data, err := ioutil.ReadFile(targetTempFile)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	i, err := strconv.ParseFloat(strings.TrimSpace(string(data)), 64)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	targetCameraTemp = i
+}
 
 func readTemps() {
 
@@ -135,6 +159,8 @@ type MotionProcessor struct {
 	sunsetOffset        int
 	nextSunriseCheck    time.Time
 	log                 *loglimiter.LogLimiter
+	lastCameraTempSave  time.Time
+	finishedWarmup      bool
 }
 
 type RecordingListener interface {
@@ -149,6 +175,8 @@ func (mp *MotionProcessor) Process(rawFrame []byte) error {
 		return err
 	}
 	mp.process(frame)
+	mp.cameraTempControll(frame)
+
 	if mp.conf.LogRate != 0 && frame.Status.FrameCount%mp.conf.LogRate == 0 {
 		go func() {
 			if err := mp.csvLog(frame); err != nil {
@@ -157,6 +185,41 @@ func (mp *MotionProcessor) Process(rawFrame []byte) error {
 		}()
 	}
 	return nil
+}
+
+func (mp *MotionProcessor) cameraTempControll(frame *cptvframe.Frame) {
+	if mp.finishedWarmup {
+		if frame.Status.TimeOn-frame.Status.LastFFCTime > 2*time.Minute &&
+			frame.Status.TimeOn > 30*time.Minute &&
+			time.Now().Sub(mp.lastCameraTempSave) > 30*time.Minute {
+			log.Printf("saving target temp as %v", frame.Status.TempC)
+			mp.lastCameraTempSave = time.Now()
+			err := ioutil.WriteFile(targetTempFile, []byte(fmt.Sprintf("%f", frame.Status.TempC)), 0644)
+			if err != nil {
+				log.Println(err)
+			}
+		}
+	} else {
+		if frame.Status.TimeOn > maxFFCWarmupDuration {
+			log.Printf("finished camera warmup beacuse warmup time exceeded %v", maxFFCWarmupDuration)
+			mp.finishedWarmup = true
+		} else if frame.Status.TempC >= targetCameraTemp {
+			log.Printf("finished camera warmup beacuse target temp of %v reached or exceeded", targetCameraTemp)
+			mp.finishedWarmup = true
+		} else if frame.Status.TimeOn-frame.Status.LastFFCTime > ffcTriggerPeriod {
+			runFFC()
+		}
+	}
+}
+
+func runFFC() error {
+	log.Println("triggering FFC")
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		return err
+	}
+	recorder := conn.Object("org.cacophony.leptond", "/org/cacophony/leptond")
+	return recorder.Call("org.cacophony.leptond.RunFFC", 0).Err
 }
 
 var csvFileName = "/var/spool/feverscreen/datalog-" + time.Now().Format("2006-01-02 15:04:05") + ".csv"

--- a/webserver/api/api.go
+++ b/webserver/api/api.go
@@ -637,3 +637,17 @@ func GetNetworkInterfaces() networkState {
 func (api *ManagementAPI) GetNetworkInfo(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(GetNetworkInterfaces())
 }
+
+func (api *ManagementAPI) RunFFC(w http.ResponseWriter, r *http.Request) {
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	recorder := conn.Object("org.cacophony.leptond", "/org/cacophony/leptond")
+	err = recorder.Call("org.cacophony.leptond.RunFFC", 0).Err
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+}

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -23,6 +23,13 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"log"
+	"net/http"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
 	goconfig "github.com/TheCacophonyProject/go-config"
 	"github.com/TheCacophonyProject/go-cptv/cptvframe"
 	"github.com/feverscreen/feverscreen/headers"
@@ -30,12 +37,6 @@ import (
 	"github.com/gobuffalo/packr"
 	"github.com/gorilla/mux"
 	"golang.org/x/net/websocket"
-	"log"
-	"net/http"
-	"os/exec"
-	"strings"
-	"sync"
-	"time"
 )
 
 const (
@@ -256,6 +257,7 @@ func Run() error {
 	apiRouter.HandleFunc("/camera/snapshot", apiObj.TakeSnapshot).Methods("PUT")
 	apiRouter.HandleFunc("/camera/snapshot-raw", apiObj.TakeRawSnapshot).Methods("PUT")
 	apiRouter.HandleFunc("/camera/metadata", apiObj.FrameMetadata).Methods("GET")
+	apiRouter.HandleFunc("/camera/run-ffc", apiObj.RunFFC).Methods("PUT")
 	apiRouter.HandleFunc("/signal-strength", apiObj.GetSignalStrength).Methods("GET")
 	apiRouter.HandleFunc("/reregister", apiObj.Reregister).Methods("POST")
 	apiRouter.HandleFunc("/reboot", apiObj.Reboot).Methods("POST")


### PR DESCRIPTION
- Increase watchdog time for leptond. I think this might help with some cameras restarting too often.
- Request FFC events through webserver
- Camera will trigger FFC events every 5 seconds until a target temp (of the camera module) is reached. This is to help reduce warmup times.