### PR TITLE
Fixed so can run fever screen through docker on MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /feverscreen
 *.iml
 .idea
+webserver/**/*.js.map
+webserver/**/*.js
+feverscreen

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,9 @@ build-arm: install-packr
 
 .PHONY: install-packr
 install-packr:
-	go get github.com/gobuffalo/packr/packr
+  ifeq (, $(shell which packr))
+		go get github.com/gobuffalo/packr/packr
+  endif
 
 .PHONY: build
 build: install-packr

--- a/webserver/static/js/feverscreen.ts
+++ b/webserver/static/js/feverscreen.ts
@@ -2057,7 +2057,12 @@ window.onload = async function () {
         x.trim()
       );
       let deviceIp = activeInterface.IPAddresses[0];
-      deviceIp = deviceIp.substring(0, deviceIp.indexOf("/"));
+      if (window.location.hostname === "localhost") {
+        deviceIp = '127.0.0.1:' + window.location.port;
+      }
+      else {
+        deviceIp = deviceIp.substring(0, deviceIp.indexOf("/"));
+      }
       openSocket(deviceIp);
       // TODO(jon): Some basic auth for the server?
       setInterval(() => {


### PR DESCRIPTION
Changed so that on localhost only it users the window address to get the websocket address. 