### PR TITLE
Leptond now sets correct module version in camera header,

### DIFF
--- a/cmd/feverscreen/cptvfilerecorder.go
+++ b/cmd/feverscreen/cptvfilerecorder.go
@@ -31,7 +31,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-func NewCPTVFileRecorder(config *Config, camera cptvframe.CameraSpec, brand, model string) *CPTVFileRecorder {
+func NewCPTVFileRecorder(config *Config, camera cptvframe.CameraSpec, brand string, model string, serial int, firmware string) *CPTVFileRecorder {
 	motionYAML, err := yaml.Marshal(config.Motion)
 	if err != nil {
 		panic(fmt.Sprintf("failed to convert motion config to YAML: %v", err))
@@ -48,6 +48,8 @@ func NewCPTVFileRecorder(config *Config, camera cptvframe.CameraSpec, brand, mod
 		FPS:          camera.FPS(),
 		Brand:        brand,
 		Model:        model,
+		CameraSerial: serial,
+		Firmware:     firmware,
 	}
 	if config.DeviceID > 0 {
 		cptvHeader.DeviceID = config.DeviceID
@@ -61,7 +63,7 @@ func NewCPTVFileRecorder(config *Config, camera cptvframe.CameraSpec, brand, mod
 }
 
 type CPTVFileRecorder struct {
-	lock sync.Mutex
+	lock         sync.Mutex
 	outputDir    string
 	header       cptv.Header
 	minDiskSpace uint64

--- a/cmd/feverscreen/main.go
+++ b/cmd/feverscreen/main.go
@@ -150,7 +150,7 @@ func handleConn(conn net.Conn, conf *Config) error {
 		return fmt.Errorf("unable to handle frames for %s %s", header.Brand(), header.Model())
 	}
 
-	cptvRecorder := NewCPTVFileRecorder(conf, header, header.Brand(), header.Model())
+	cptvRecorder := NewCPTVFileRecorder(conf, header, header.Brand(), header.Model(), header.CameraSerial(), header.Firmware())
 	defer cptvRecorder.Stop()
 	var recorder recorder.Recorder = cptvRecorder
 

--- a/cmd/leptond/main.go
+++ b/cmd/leptond/main.go
@@ -220,7 +220,6 @@ func runCamera(conf *Config, camera *lepton3.Lepton3) error {
 		firmwareDsp = lepton3.LeptonSoftwareRevision{}
 	}
 	firmware := fmt.Sprintf("%d.%d.%d", firmwareDsp.Gpp_major, firmwareDsp.Gpp_minor, firmwareDsp.Gpp_build)
-	dsp := fmt.Sprintf("%d.%d.%d", firmwareDsp.Dsp_major, firmwareDsp.Dsp_minor, firmwareDsp.Dsp_build)
 
 	partNum, err := camera.GetPartNum()
 	if err != nil {

--- a/cmd/leptond/main.go
+++ b/cmd/leptond/main.go
@@ -210,11 +210,16 @@ func runCamera(conf *Config, camera *lepton3.Lepton3) error {
 
 	conn.SetWriteBuffer(camera.ResX() * camera.ResY() * 2 * 20)
 
+	model := lepton3.Model
+	if camera.IsRadioMetricLeptonModel() {
+		model = "lepton3.5"
+	}
+
 	camera_specs := map[string]interface{}{
 		headers.XResolution: camera.ResX(),
 		headers.YResolution: camera.ResY(),
 		headers.FrameSize:   lepton3.BytesPerFrame,
-		headers.Model:       lepton3.Model,
+		headers.Model:       model,
 		headers.Brand:       lepton3.Brand,
 		headers.FPS:         camera.FPS(),
 	}

--- a/cmd/leptond/main.go
+++ b/cmd/leptond/main.go
@@ -248,8 +248,6 @@ func runCamera(conf *Config, camera *lepton3.Lepton3) error {
 		headers.Brand:       lepton3.Brand,
 		headers.Serial:      serial,
 		headers.Firmware:    firmware,
-		headers.Dsp:         dsp, // Seems like these numbers *might* be in the wrong order for some reason.
-		headers.PartNum:     partNum,
 	}
 
 	cameraYAML, err := yaml.Marshal(cameraSpecs)

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/TheCacophonyProject/event-reporter v1.3.2-0.20200210010421-ca3fcb76a231
 	github.com/TheCacophonyProject/go-api v0.0.0-20200210030345-722430c24511
 	github.com/TheCacophonyProject/go-config v1.4.0
-	github.com/TheCacophonyProject/go-cptv v0.0.0-20200225002107-8095b1b6b929
+	github.com/TheCacophonyProject/go-cptv v0.0.0-20200616224711-fc633122087a // indirect
 	github.com/TheCacophonyProject/lepton3 v0.0.0-20200615223119-045204f5d53f
 	github.com/TheCacophonyProject/management-interface v1.6.0
 	github.com/TheCacophonyProject/rtc-utils v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/TheCacophonyProject/event-reporter v1.3.2-0.20200210010421-ca3fcb76a231
 	github.com/TheCacophonyProject/go-api v0.0.0-20200210030345-722430c24511
 	github.com/TheCacophonyProject/go-config v1.4.0
-	github.com/TheCacophonyProject/go-cptv v0.0.0-20200616224711-fc633122087a // indirect
+	github.com/TheCacophonyProject/go-cptv v0.0.0-20200616224711-fc633122087a
 	github.com/TheCacophonyProject/lepton3 v0.0.0-20200615223119-045204f5d53f
 	github.com/TheCacophonyProject/management-interface v1.6.0
 	github.com/TheCacophonyProject/rtc-utils v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/feverscreen/feverscreen
 go 1.13
 
 // We maintain a custom fork of periph.io at the moment.
-replace periph.io/x/periph => github.com/TheCacophonyProject/periph v1.0.1-0.20200331204442-4717ddfb6980
+replace periph.io/x/periph => github.com/TheCacophonyProject/periph v2.1.1-0.20200614235321-4c791a75f339+incompatible
 
 replace github.com/TheCacophonyProject/go-config => github.com/feverscreen/go-config v1.7.0
 
@@ -14,7 +14,7 @@ require (
 	github.com/TheCacophonyProject/go-api v0.0.0-20200210030345-722430c24511
 	github.com/TheCacophonyProject/go-config v1.4.0
 	github.com/TheCacophonyProject/go-cptv v0.0.0-20200225002107-8095b1b6b929
-	github.com/TheCacophonyProject/lepton3 v0.0.0-20200430221413-9df342ce97f9
+	github.com/TheCacophonyProject/lepton3 v0.0.0-20200615005818-de6e18df924d
 	github.com/TheCacophonyProject/management-interface v1.6.0
 	github.com/TheCacophonyProject/rtc-utils v1.3.0
 	github.com/TheCacophonyProject/window v0.0.0-20200312071457-7fc8799fdce7

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/feverscreen/feverscreen
 go 1.13
 
 // We maintain a custom fork of periph.io at the moment.
-replace periph.io/x/periph => github.com/TheCacophonyProject/periph v2.1.1-0.20200614235321-4c791a75f339+incompatible
+replace periph.io/x/periph => github.com/TheCacophonyProject/periph v2.1.1-0.20200615222341-6834cd5be8c1+incompatible
 
 replace github.com/TheCacophonyProject/go-config => github.com/feverscreen/go-config v1.7.0
 
@@ -14,7 +14,7 @@ require (
 	github.com/TheCacophonyProject/go-api v0.0.0-20200210030345-722430c24511
 	github.com/TheCacophonyProject/go-config v1.4.0
 	github.com/TheCacophonyProject/go-cptv v0.0.0-20200225002107-8095b1b6b929
-	github.com/TheCacophonyProject/lepton3 v0.0.0-20200615005818-de6e18df924d
+	github.com/TheCacophonyProject/lepton3 v0.0.0-20200615223119-045204f5d53f
 	github.com/TheCacophonyProject/management-interface v1.6.0
 	github.com/TheCacophonyProject/rtc-utils v1.3.0
 	github.com/TheCacophonyProject/window v0.0.0-20200312071457-7fc8799fdce7

--- a/go.sum
+++ b/go.sum
@@ -18,11 +18,9 @@ github.com/TheCacophonyProject/go-api v0.0.0-20200210030345-722430c24511/go.mod 
 github.com/TheCacophonyProject/go-cptv v0.0.0-20200116020937-858bd8b71512/go.mod h1:8H6Aaft5549sIWxcsuCIL2o60/TQkoF93fVoSTpgZb8=
 github.com/TheCacophonyProject/go-cptv v0.0.0-20200225002107-8095b1b6b929 h1:Ew+XHCyNuokz/1mmsyMBvpdDfYgwGd1Wc9V+RfWvTWM=
 github.com/TheCacophonyProject/go-cptv v0.0.0-20200225002107-8095b1b6b929/go.mod h1:Vg73Ezn4kr8qDNP9LNgjki9qgi+5T/0Uc9oDyflaYUY=
+github.com/TheCacophonyProject/go-cptv v0.0.0-20200616224711-fc633122087a h1:HgrFoyS+wwf5LH37q8E+Kew7CAhksXyeA31Qh1C6T2w=
+github.com/TheCacophonyProject/go-cptv v0.0.0-20200616224711-fc633122087a/go.mod h1:Vg73Ezn4kr8qDNP9LNgjki9qgi+5T/0Uc9oDyflaYUY=
 github.com/TheCacophonyProject/lepton3 v0.0.0-20200121020734-2ae28662e1bc/go.mod h1:xzPAWtvVCbJdJC2Gn1cG0Ovs/VP7XGGiQpUU8wU4HME=
-github.com/TheCacophonyProject/lepton3 v0.0.0-20200615002900-47b22fae5e9c h1:c6oijjyXw40XPNswo4Vz/FjsIfpICzkfmJ4ZHpY3huw=
-github.com/TheCacophonyProject/lepton3 v0.0.0-20200615002900-47b22fae5e9c/go.mod h1:JRJHaF3qLZWOH1lu/UZ/TFb2nJQDJHDZWtMEoCqdlzA=
-github.com/TheCacophonyProject/lepton3 v0.0.0-20200615005818-de6e18df924d h1:3ybfNgTHKtDfhm7HJgT48ViyPyDYaW/ghPMqyDdl1So=
-github.com/TheCacophonyProject/lepton3 v0.0.0-20200615005818-de6e18df924d/go.mod h1:JRJHaF3qLZWOH1lu/UZ/TFb2nJQDJHDZWtMEoCqdlzA=
 github.com/TheCacophonyProject/lepton3 v0.0.0-20200615223119-045204f5d53f h1:yai2yZ3R9ML1me/9Sm3pXzTYjUYK8h+gDaQxFwHHDQY=
 github.com/TheCacophonyProject/lepton3 v0.0.0-20200615223119-045204f5d53f/go.mod h1:ehcZ1dKt5kphmF8VQSZ9JpYRugEmXVChMVtENH960Ws=
 github.com/TheCacophonyProject/management-interface v1.6.0 h1:LOb8AoDLZp03ev83JiIZ0Sk7QZKEGvhcHMrcc2qJUFA=
@@ -30,10 +28,6 @@ github.com/TheCacophonyProject/management-interface v1.6.0/go.mod h1:56VgQqLkRW7
 github.com/TheCacophonyProject/modemd v0.0.0-20190605010435-ae5b0f2eb760/go.mod h1:bfwJ/WcvDY9XtHKC5tcRfVrU8RWaW8DLYAAUfsrJr/4=
 github.com/TheCacophonyProject/modemd v0.0.0-20190708011609-1940f5b6677b h1:iJVZlC3nzjJ2EoWLBr7zKhL7t9hUleghmUIC+3ObB88=
 github.com/TheCacophonyProject/modemd v0.0.0-20190708011609-1940f5b6677b/go.mod h1:txGgnRinv6H0/jB4n71MpuS+2qtu8tAlntIjY5udXDU=
-github.com/TheCacophonyProject/periph v1.0.1-0.20200331204442-4717ddfb6980 h1:ufuOHiP2KrkytgNQM21+UrXiB6eHw6Qyeblhkj5vElo=
-github.com/TheCacophonyProject/periph v1.0.1-0.20200331204442-4717ddfb6980/go.mod h1:EFGf/DZTId9qC+rSbBgtdjuXFMSSg6sY5YgUIb06aqE=
-github.com/TheCacophonyProject/periph v2.1.1-0.20200614235321-4c791a75f339+incompatible h1:ypl7jt8hM4lUS9psxZuyEB6UlsB8+I1Lp8xZjwRKGUc=
-github.com/TheCacophonyProject/periph v2.1.1-0.20200614235321-4c791a75f339+incompatible/go.mod h1:K1wa07sGXKzV0G9p+4R069mZk4GOpqKW8GU6/k+BrIo=
 github.com/TheCacophonyProject/periph v2.1.1-0.20200615222341-6834cd5be8c1+incompatible h1:0pEn1FoMTgOZR3EkqOTiqd0++jOS/jWlGrbvOHK0/KM=
 github.com/TheCacophonyProject/periph v2.1.1-0.20200615222341-6834cd5be8c1+incompatible/go.mod h1:K1wa07sGXKzV0G9p+4R069mZk4GOpqKW8GU6/k+BrIo=
 github.com/TheCacophonyProject/rtc-utils v1.2.0/go.mod h1:uV1SIy93TLZrrBcqDczUNFUz2G/Pk6pZNUdTRglmANU=

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,10 @@ github.com/TheCacophonyProject/go-cptv v0.0.0-20200116020937-858bd8b71512/go.mod
 github.com/TheCacophonyProject/go-cptv v0.0.0-20200225002107-8095b1b6b929 h1:Ew+XHCyNuokz/1mmsyMBvpdDfYgwGd1Wc9V+RfWvTWM=
 github.com/TheCacophonyProject/go-cptv v0.0.0-20200225002107-8095b1b6b929/go.mod h1:Vg73Ezn4kr8qDNP9LNgjki9qgi+5T/0Uc9oDyflaYUY=
 github.com/TheCacophonyProject/lepton3 v0.0.0-20200121020734-2ae28662e1bc/go.mod h1:xzPAWtvVCbJdJC2Gn1cG0Ovs/VP7XGGiQpUU8wU4HME=
-github.com/TheCacophonyProject/lepton3 v0.0.0-20200430221413-9df342ce97f9 h1:WuMZ1bqqxS5YgzduhQp0MEuA/YEOo3irfHN/DTlwBvA=
-github.com/TheCacophonyProject/lepton3 v0.0.0-20200430221413-9df342ce97f9/go.mod h1:W+t2+4QW22Tv/Vc6m0jwtm1S115o2kJKPdd28wV5LeA=
+github.com/TheCacophonyProject/lepton3 v0.0.0-20200615002900-47b22fae5e9c h1:c6oijjyXw40XPNswo4Vz/FjsIfpICzkfmJ4ZHpY3huw=
+github.com/TheCacophonyProject/lepton3 v0.0.0-20200615002900-47b22fae5e9c/go.mod h1:JRJHaF3qLZWOH1lu/UZ/TFb2nJQDJHDZWtMEoCqdlzA=
+github.com/TheCacophonyProject/lepton3 v0.0.0-20200615005818-de6e18df924d h1:3ybfNgTHKtDfhm7HJgT48ViyPyDYaW/ghPMqyDdl1So=
+github.com/TheCacophonyProject/lepton3 v0.0.0-20200615005818-de6e18df924d/go.mod h1:JRJHaF3qLZWOH1lu/UZ/TFb2nJQDJHDZWtMEoCqdlzA=
 github.com/TheCacophonyProject/management-interface v1.6.0 h1:LOb8AoDLZp03ev83JiIZ0Sk7QZKEGvhcHMrcc2qJUFA=
 github.com/TheCacophonyProject/management-interface v1.6.0/go.mod h1:56VgQqLkRW7Kyxel9kOcpKPsrlhFv2CdG8dv6WkO+jY=
 github.com/TheCacophonyProject/modemd v0.0.0-20190605010435-ae5b0f2eb760/go.mod h1:bfwJ/WcvDY9XtHKC5tcRfVrU8RWaW8DLYAAUfsrJr/4=
@@ -28,6 +30,8 @@ github.com/TheCacophonyProject/modemd v0.0.0-20190708011609-1940f5b6677b h1:iJVZ
 github.com/TheCacophonyProject/modemd v0.0.0-20190708011609-1940f5b6677b/go.mod h1:txGgnRinv6H0/jB4n71MpuS+2qtu8tAlntIjY5udXDU=
 github.com/TheCacophonyProject/periph v1.0.1-0.20200331204442-4717ddfb6980 h1:ufuOHiP2KrkytgNQM21+UrXiB6eHw6Qyeblhkj5vElo=
 github.com/TheCacophonyProject/periph v1.0.1-0.20200331204442-4717ddfb6980/go.mod h1:EFGf/DZTId9qC+rSbBgtdjuXFMSSg6sY5YgUIb06aqE=
+github.com/TheCacophonyProject/periph v2.1.1-0.20200614235321-4c791a75f339+incompatible h1:ypl7jt8hM4lUS9psxZuyEB6UlsB8+I1Lp8xZjwRKGUc=
+github.com/TheCacophonyProject/periph v2.1.1-0.20200614235321-4c791a75f339+incompatible/go.mod h1:K1wa07sGXKzV0G9p+4R069mZk4GOpqKW8GU6/k+BrIo=
 github.com/TheCacophonyProject/rtc-utils v1.2.0/go.mod h1:uV1SIy93TLZrrBcqDczUNFUz2G/Pk6pZNUdTRglmANU=
 github.com/TheCacophonyProject/rtc-utils v1.3.0 h1:gZO7L1BFKyx40xnNuLnSoLs97jHkFFqPzO8ue5CB5Vk=
 github.com/TheCacophonyProject/rtc-utils v1.3.0/go.mod h1:uV1SIy93TLZrrBcqDczUNFUz2G/Pk6pZNUdTRglmANU=

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/TheCacophonyProject/lepton3 v0.0.0-20200615002900-47b22fae5e9c h1:c6o
 github.com/TheCacophonyProject/lepton3 v0.0.0-20200615002900-47b22fae5e9c/go.mod h1:JRJHaF3qLZWOH1lu/UZ/TFb2nJQDJHDZWtMEoCqdlzA=
 github.com/TheCacophonyProject/lepton3 v0.0.0-20200615005818-de6e18df924d h1:3ybfNgTHKtDfhm7HJgT48ViyPyDYaW/ghPMqyDdl1So=
 github.com/TheCacophonyProject/lepton3 v0.0.0-20200615005818-de6e18df924d/go.mod h1:JRJHaF3qLZWOH1lu/UZ/TFb2nJQDJHDZWtMEoCqdlzA=
+github.com/TheCacophonyProject/lepton3 v0.0.0-20200615223119-045204f5d53f h1:yai2yZ3R9ML1me/9Sm3pXzTYjUYK8h+gDaQxFwHHDQY=
+github.com/TheCacophonyProject/lepton3 v0.0.0-20200615223119-045204f5d53f/go.mod h1:ehcZ1dKt5kphmF8VQSZ9JpYRugEmXVChMVtENH960Ws=
 github.com/TheCacophonyProject/management-interface v1.6.0 h1:LOb8AoDLZp03ev83JiIZ0Sk7QZKEGvhcHMrcc2qJUFA=
 github.com/TheCacophonyProject/management-interface v1.6.0/go.mod h1:56VgQqLkRW7Kyxel9kOcpKPsrlhFv2CdG8dv6WkO+jY=
 github.com/TheCacophonyProject/modemd v0.0.0-20190605010435-ae5b0f2eb760/go.mod h1:bfwJ/WcvDY9XtHKC5tcRfVrU8RWaW8DLYAAUfsrJr/4=
@@ -32,6 +34,8 @@ github.com/TheCacophonyProject/periph v1.0.1-0.20200331204442-4717ddfb6980 h1:uf
 github.com/TheCacophonyProject/periph v1.0.1-0.20200331204442-4717ddfb6980/go.mod h1:EFGf/DZTId9qC+rSbBgtdjuXFMSSg6sY5YgUIb06aqE=
 github.com/TheCacophonyProject/periph v2.1.1-0.20200614235321-4c791a75f339+incompatible h1:ypl7jt8hM4lUS9psxZuyEB6UlsB8+I1Lp8xZjwRKGUc=
 github.com/TheCacophonyProject/periph v2.1.1-0.20200614235321-4c791a75f339+incompatible/go.mod h1:K1wa07sGXKzV0G9p+4R069mZk4GOpqKW8GU6/k+BrIo=
+github.com/TheCacophonyProject/periph v2.1.1-0.20200615222341-6834cd5be8c1+incompatible h1:0pEn1FoMTgOZR3EkqOTiqd0++jOS/jWlGrbvOHK0/KM=
+github.com/TheCacophonyProject/periph v2.1.1-0.20200615222341-6834cd5be8c1+incompatible/go.mod h1:K1wa07sGXKzV0G9p+4R069mZk4GOpqKW8GU6/k+BrIo=
 github.com/TheCacophonyProject/rtc-utils v1.2.0/go.mod h1:uV1SIy93TLZrrBcqDczUNFUz2G/Pk6pZNUdTRglmANU=
 github.com/TheCacophonyProject/rtc-utils v1.3.0 h1:gZO7L1BFKyx40xnNuLnSoLs97jHkFFqPzO8ue5CB5Vk=
 github.com/TheCacophonyProject/rtc-utils v1.3.0/go.mod h1:uV1SIy93TLZrrBcqDczUNFUz2G/Pk6pZNUdTRglmANU=

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,6 @@ github.com/TheCacophonyProject/go-api v0.0.0-20190923033957-174cea2ac81c/go.mod 
 github.com/TheCacophonyProject/go-api v0.0.0-20200210030345-722430c24511 h1:UHA91o2OV6vgO4zrZKFl15qjKlVNyj0b1oiRHKh+/VY=
 github.com/TheCacophonyProject/go-api v0.0.0-20200210030345-722430c24511/go.mod h1:FfMpa4cFhNXQ9tuKG18HO6yLExezcJhzjUjBOFocrQw=
 github.com/TheCacophonyProject/go-cptv v0.0.0-20200116020937-858bd8b71512/go.mod h1:8H6Aaft5549sIWxcsuCIL2o60/TQkoF93fVoSTpgZb8=
-github.com/TheCacophonyProject/go-cptv v0.0.0-20200225002107-8095b1b6b929 h1:Ew+XHCyNuokz/1mmsyMBvpdDfYgwGd1Wc9V+RfWvTWM=
-github.com/TheCacophonyProject/go-cptv v0.0.0-20200225002107-8095b1b6b929/go.mod h1:Vg73Ezn4kr8qDNP9LNgjki9qgi+5T/0Uc9oDyflaYUY=
 github.com/TheCacophonyProject/go-cptv v0.0.0-20200616224711-fc633122087a h1:HgrFoyS+wwf5LH37q8E+Kew7CAhksXyeA31Qh1C6T2w=
 github.com/TheCacophonyProject/go-cptv v0.0.0-20200616224711-fc633122087a/go.mod h1:Vg73Ezn4kr8qDNP9LNgjki9qgi+5T/0Uc9oDyflaYUY=
 github.com/TheCacophonyProject/lepton3 v0.0.0-20200121020734-2ae28662e1bc/go.mod h1:xzPAWtvVCbJdJC2Gn1cG0Ovs/VP7XGGiQpUU8wU4HME=

--- a/headers/headerinfo.go
+++ b/headers/headerinfo.go
@@ -19,8 +19,8 @@ package headers
 import (
 	"bufio"
 	"bytes"
-	"strings"
 	"encoding/json"
+	"strings"
 
 	"gopkg.in/yaml.v1"
 )
@@ -34,20 +34,24 @@ type HeaderInfo struct {
 	framesize int
 	brand     string
 	model     string
+	serial    int
+	firmware  string
 }
 
 func (h *HeaderInfo) MarshalJSON() ([]byte, error) {
-    j, err := json.Marshal(map[string]interface{}{
-			"ResX":  h.ResX(),
-			"ResY":  h.ResY(),
-			"FPS":   h.FPS(),
-			"Model": h.Model(),
-			"Brand": h.Brand(),
-		})
-    if err != nil {
-           return nil, err
-    }
-    return j, nil
+	j, err := json.Marshal(map[string]interface{}{
+		"ResX":         h.ResX(),
+		"ResY":         h.ResY(),
+		"FPS":          h.FPS(),
+		"Model":        h.Model(),
+		"Brand":        h.Brand(),
+		"Firmware":     h.Firmware(),
+		"CameraSerial": h.CameraSerial(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return j, nil
 }
 
 // ResX implements cptvframe.CameraSpec.
@@ -81,6 +85,16 @@ func (h *HeaderInfo) Brand() string {
 	return h.brand
 }
 
+// Camera module firmware revision i.e. 1.2.3
+func (h *HeaderInfo) Firmware() string {
+	return h.firmware
+}
+
+// Camera module unique serial#
+func (h *HeaderInfo) CameraSerial() int {
+	return h.serial
+}
+
 func ReadHeaderInfo(reader *bufio.Reader) (*HeaderInfo, error) {
 	var buf bytes.Buffer
 	for {
@@ -106,6 +120,8 @@ func ReadHeaderInfo(reader *bufio.Reader) (*HeaderInfo, error) {
 		framesize: toInt(h[FrameSize]),
 		brand:     toStr(h[Brand]),
 		model:     toStr(h[Model]),
+		serial:    toInt(h[Serial]),
+		firmware:  toStr(h[Firmware]),
 	}, nil
 }
 

--- a/headers/headers.go
+++ b/headers/headers.go
@@ -8,8 +8,6 @@ const (
 	Brand       = "Brand"
 	PixelBits   = "PixelBits"
 	FrameSize   = "FrameSize"
-	Firmware    = "FirmwareVersion"
-	Dsp         = "DSPVersion"
-	Serial      = "Serial"
-	PartNum     = "PartNum"
+	Firmware    = "Firmware"
+	Serial      = "CameraSerial"
 )

--- a/headers/headers.go
+++ b/headers/headers.go
@@ -8,4 +8,8 @@ const (
 	Brand       = "Brand"
 	PixelBits   = "PixelBits"
 	FrameSize   = "FrameSize"
+	Firmware    = "FirmwareVersion"
+	Dsp         = "DSPVersion"
+	Serial      = "Serial"
+	PartNum     = "PartNum"
 )


### PR DESCRIPTION
depending on whether it's possible to access TLinearEnabled
radiometry functionality that only exists on lepton 3.5