### PR TITLE
Fix bad merge overwriting thermal reference temp.

### DIFF
--- a/webserver/static/js/feverscreen.ts
+++ b/webserver/static/js/feverscreen.ts
@@ -1784,9 +1784,6 @@ window.onload = async function () {
 
   async function startScan(shouldSaveCalibration = true) {
     if (shouldSaveCalibration) {
-      GThermalRefTemp =
-        GCalibrateTemperatureCelsius -
-        (UncorrectedHotspot - UncorrectedThermalRef) * 0.01;
       await DeviceApi.saveCalibration({
         ThermalRefTemp: GThermalRefTemp,
         SnapshotTime: GCalibrateSnapshotTime,


### PR DESCRIPTION
Looks like somewhere along the way I merged this incorrectly.  This should not be here, and can explain why we've been seeing strange results.