### PR TITLE
Only check for updates from feverscreen apt source

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,6 +69,7 @@ nfpms:
     "_release/tko-release-channel": "/usr/local/bin/tko-release-channel"
     "_release/tko-update": "/usr/local/bin/tko-update"
     "_release/feverscreen-apt-preferences": "/etc/apt/preferences.d/feverscreen"
+    "_release/feverscreen-only-apt-config": "/etc/tko/feverscreen-only-apt-config"
   scripts:
     postinstall: "_release/postinstall.sh"
 

--- a/_release/feverscreen-only-apt-config
+++ b/_release/feverscreen-only-apt-config
@@ -1,0 +1,5 @@
+#When running 'apt-get udpate' if you select this as the config file it will only update feverscreen, taking a lot les time.
+
+Dir::Etc::sourcelist "sources.list.d/feverscreen.list";
+Dir::Etc::sourceparts "-";
+APT::Get::List-Cleanup "0";

--- a/_release/tko-release-channel
+++ b/_release/tko-release-channel
@@ -12,11 +12,11 @@ releaseChannel=$1
 case $releaseChannel in
     "stable")
     echo "setting daily update at 10am"
-    echo "0 10 * * * root sudo apt-get update; sudo apt-get install feverscreen -y --allow-downgrades"  > /etc/cron.d/update-feverscren
+    echo "0 10 * * * root sudo apt-get update -c '/etc/tko/feverscreen-only-apt-config'; sudo apt-get install feverscreen -y --allow-downgrades"  > /etc/cron.d/update-feverscren
     ;;
     "beta"|"nightly")
     echo "setting hourly update"
-    echo "0 * * * * root sudo apt-get update; sudo apt-get install feverscreen -y --allow-downgrades"  > /etc/cron.d/update-feverscren
+    echo "0 * * * * root sudo apt-get update -c '/etc/tko/feverscreen-only-apt-config'; sudo apt-get install feverscreen -y --allow-downgrades"  > /etc/cron.d/update-feverscren
     ;;
     *)
     echo "unknown release channel '$releaseChannel', choose stable, beta, or nightly."

--- a/_release/tko-update
+++ b/_release/tko-update
@@ -3,7 +3,7 @@
 set -e
 
 echo "Running update of TKO"
-sudo apt-get update
+sudo apt-get update -c "/etc/tko/feverscreen-only-apt-config"
 sudo dpkg --configure -a
 sudo apt-get install feverscreen -y --allow-downgrades
 echo "Finished update of TKO"

--- a/webserver/api/api.go
+++ b/webserver/api/api.go
@@ -708,7 +708,7 @@ func (api *ManagementAPI) Update(w http.ResponseWriter, r *http.Request) {
 
 func (api *ManagementAPI) CheckForUpdate(w http.ResponseWriter, r *http.Request) {
 	log.Println("Checking for updates")
-	if err := exec.Command("apt-get", "update").Run(); err != nil {
+	if err := exec.Command("apt-get", "update", "-c", "/etc/tko/feverscreen-only-apt-config").Run(); err != nil {
 		w.Write([]byte("failed to check for updates"))
 	}
 }


### PR DESCRIPTION
Add apt config to only check for updates from feverscreen apt source increasing the speed of running `apt-get update` from 8-14s to 2-3s (on my wifi)
